### PR TITLE
Remove After=syslog.target from systemd unit files and improve descripti...

### DIFF
--- a/rpm/sshd.service
+++ b/rpm/sshd.service
@@ -1,6 +1,5 @@
 [Unit]
-Description=OpenSSH Daemon
-After=syslog.target 
+Description=OpenSSH server daemon
 
 [Service]
 EnvironmentFile=-/etc/ssh/ssh-env.conf

--- a/rpm/sshd.socket
+++ b/rpm/sshd.socket
@@ -1,4 +1,5 @@
 [Unit]
+Description=OpenSSH Server Socket
 Conflicts=sshd.service
 
 [Socket]

--- a/rpm/sshd@.service
+++ b/rpm/sshd@.service
@@ -1,6 +1,5 @@
 [Unit]
-Description=SSH Per-Connection Server
-After=syslog.target 
+Description=OpenSSH per-connection server daemon
 
 [Service]
 EnvironmentFile=-/etc/ssh/ssh-env.conf
@@ -9,5 +8,3 @@ ExecReload=/bin/kill -HUP $MAINPID
 StandardInput=socket
 StandardOutput=socket
 
-[Install]
-WantedBy=network.target


### PR DESCRIPTION
...ons.

Related systemd documentation:
http://www.freedesktop.org/wiki/Software/systemd/syslog/

"Newer systemd versions (v35+) do not support non-socket-activated
syslog daemons anymore and we do no longer recommend people to order
their units after syslog.target."

Related systemd commit:
http://cgit.freedesktop.org/systemd/systemd/commit/?id=4b7b2efb69943aae0f8287df6e28b637c50fe318

Signed-off-by: Marko Saukko marko.saukko@jolla.com
