### PR TITLE
Make keygeneration start as early as possible and run paraller.

### DIFF
--- a/rpm/sshd-hostkeys
+++ b/rpm/sshd-hostkeys
@@ -11,6 +11,7 @@ make_key()
 }
 
 # make_key ssh_host_key rsa1
-make_key ssh_host_rsa_key rsa
+make_key ssh_host_rsa_key rsa&
 make_key ssh_host_dsa_key dsa
+wait
 

--- a/rpm/sshd-keys.service
+++ b/rpm/sshd-keys.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Create sshd host keys
+DefaultDependencies=no
+After=local-fs.target
+Conflicts=shutdown.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
[keygen] Make sshd-keys.service start earlier.
[hostkeys] Run key generation parallel and make use of multicore cpu's.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>