### PR TITLE
Refactor startup to use only one keygen.

### DIFF
--- a/rpm/openssh.spec
+++ b/rpm/openssh.spec
@@ -357,7 +357,6 @@ install -D -m 0755 %{SOURCE8} %{buildroot}/usr/sbin/sshd-hostkeys
 mkdir -p %{buildroot}/%{_lib}/systemd/system/multi-user.target.wants
 ln -s ../sshd-keys.service %{buildroot}/%{_lib}/systemd/system/multi-user.target.wants/sshd-keys.service
 
-
 %if ! %{no_gnome_askpass}
 install -s contrib/gnome-ssh-askpass $RPM_BUILD_ROOT%{_libexecdir}/openssh/gnome-ssh-askpass
 %endif
@@ -395,20 +394,6 @@ if [ "$1" != 0 -a -r /var/run/sshd.pid ] ; then
 	touch /var/run/sshd.restart
 fi
 
-%triggerun server -- openssh-server < 2.5.0p1
-# Count the number of HostKey and HostDsaKey statements we have.
-gawk	'BEGIN {IGNORECASE=1}
-	 /^hostkey/ || /^hostdsakey/ {sawhostkey = sawhostkey + 1}
-	 END {exit sawhostkey}' /etc/ssh/sshd_config
-# And if we only found one, we know the client was relying on the old default
-# behavior, which loaded the the SSH2 DSA host key when HostDsaKey wasn't
-# specified.  Now that HostKey is used for both SSH1 and SSH2 keys, specifying
-# one nullifies the default, which would have loaded both.
-if [ $? -eq 1 ] ; then
-	echo HostKey /etc/ssh/ssh_host_rsa_key >> /etc/ssh/sshd_config
-	echo HostKey /etc/ssh/ssh_host_dsa_key >> /etc/ssh/sshd_config
-fi
-
 %pre
 # We have nasty problem with old openssh package
 # Old package tries to stop sshd.service during uninstallation
@@ -426,6 +411,12 @@ if [ ! -f $SSHD_SERVICE -a -d /usr/libexec/openssh ]; then
     echo "ExecStart=/bin/true" >> $SSHD_SERVICE || :
     systemctl daemon-reload &> /dev/null || :
 fi
+
+%post
+# In the past we had sshd-keygen masked to disable it, we changed this
+# so that it starts if keys are not present on bootup so one always
+# would have keys even if something destroys those.
+systemctl unmask sshd-keygen.service &> /dev/null || :
 
 %posttrans
 # See comment in pre

--- a/rpm/sshd-keys.service
+++ b/rpm/sshd-keys.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Create sshd host keys
 DefaultDependencies=no
+ConditionPathExists=|!/etc/ssh/ssh_host_rsa_key
+PartOf=sshd.service sshd.socket
 After=local-fs.target
 Conflicts=shutdown.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/sshd-hostkeys
-ExecStartPost=/bin/sync ; -/bin/ln -s /dev/null /etc/systemd/system/sshd-keys.service
-
-[Install]
-WantedBy=multi-user.target
+RemainAfterExit=yes
 

--- a/rpm/sshd.service
+++ b/rpm/sshd.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=OpenSSH server daemon
+Wants=sshd-keys.service
+After=sshd-keys.service
 
 [Service]
 EnvironmentFile=-/etc/ssh/ssh-env.conf
@@ -8,7 +10,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
 StandardOutput=syslog
-ExecStartPre=/bin/bash -c 'if [ \( ! -s /etc/ssh/ssh_host_dsa_key \) -a \( ! -s /etc/ssh/ssh_host_dsa_key.pub \) -a \( ! -s /etc/ssh/ssh_host_rsa_key \) -a \( ! -s /etc/ssh/ssh_host_rsa_key.pub \) ]; then /usr/sbin/sshd-hostkeys; fi'
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/sshd.socket
+++ b/rpm/sshd.socket
@@ -5,7 +5,6 @@ Conflicts=sshd.service
 [Socket]
 ListenStream=22
 Accept=yes
-ExecStartPre=/bin/bash -c 'if [ \( ! -s /etc/ssh/ssh_host_dsa_key \) -a \( ! -s /etc/ssh/ssh_host_dsa_key.pub \) -a \( ! -s /etc/ssh/ssh_host_rsa_key \) -a \( ! -s /etc/ssh/ssh_host_rsa_key.pub \) ]; then /usr/sbin/sshd-hostkeys; fi'
 
 [Install]
 WantedBy=sockets.target

--- a/rpm/sshd@.service
+++ b/rpm/sshd@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=OpenSSH per-connection server daemon
+Wants=sshd-keys.service
+After=sshd-keys.service
 
 [Service]
 EnvironmentFile=-/etc/ssh/ssh-env.conf


### PR DESCRIPTION
WIP: Not fully tested yet.

[bootup] Refactor startup to use keygen only once.

In the past there was possible race condition where multiple
keygenerators were started. Resolve the issue by removing extra calls to
the key generator and make services to depend on the one and only
keygen.

Also cleanup the .spec file a bit from old triggerun script.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>